### PR TITLE
Spec reporter: show times in a different color.

### DIFF
--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -10,6 +10,7 @@ function indentLine(line) {
 
 function handleTest(test) {
   var text;
+  var time = chalk.grey(' ' + test.time +  'ms');
   var output = [];
 
   if (test.success) {
@@ -17,7 +18,7 @@ function handleTest(test) {
   } else {
     text = chalk.red(figures.cross);
   }
-  output.push(INDENT + text + ' ' +  test.name + ' (' + test.time +  ' ms)\n');
+  output.push(INDENT + text + ' ' +  test.name + time + '\n');
 
   if (test.error) {
     output.push(INDENT + '   ' + test.error.message + '\n');

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -34,7 +34,7 @@ function handleTest(test) {
 function handleEnd(info) {
   var output = [];
 
-  output.push('\n\n'  + INDENT + info.time + ' ms\n');
+  output.push('\n\n'  + INDENT + chalk.grey(info.time + 'ms total\n'));
   output.push(INDENT + info.testCount + ' tests\n');
   output.push(INDENT + chalk.green((info.testCount - info.errors.length) + ' passed\n'));
   if (info.errors.length) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -20,7 +20,7 @@ test('command sync -r=tap', function(t) {
 
 test('command sync -r=spec', function(t) {
   exec('node examples/sync -r=spec', function (error, stdout, stderr) {
-    t.match(stdout, /  ✔ simple sync pass \([0-9]+ ms\)\n  ✔ simple sync pass 2 \([0-9]+ ms\)\n\n\n  [0-9]+ ms\n  2 tests\n  2 passed\n\n  Pass!\n/);
+    t.match(stdout, /  ✔ simple sync pass [0-9]+ms\n  ✔ simple sync pass 2 [0-9]+ms\n\n\n  [0-9]+ms total\n  2 tests\n  2 passed\n\n  Pass!\n/);
     t.end();
   });
 });
@@ -94,7 +94,7 @@ test('invalid assertion tap', function(t) {
 test('invalid assertion spec', function(t) {
   exec('node test/fixtures/string-error-test -r=spec', function (error, stdout, stderr) {
     t.ok(error);
-    t.match(stdout, /  ✖ string assertion \([0-9]+ ms\)\n     hello\n      \n\n\n  [0-9]+ ms\n  1 tests\n  0 passed\n  1 failed\n/);
+    t.match(stdout, /  ✖ string assertion [0-9]+ms\n     hello\n      \n\n\n  [0-9]+ms total\n  1 tests\n  0 passed\n  1 failed\n/);
     t.end();
   });
 });


### PR DESCRIPTION
I thought this was a nice small improvement to the reporter output. This also
removes the parentheses and space ("10ms" instead of "(10 ms)"), which
is a matter of taste so I can put them back in if desired.