### PR TITLE
Show group names in the spec reporter.

### DIFF
--- a/examples/sync.js
+++ b/examples/sync.js
@@ -4,7 +4,7 @@ node examples/sync.js
  */
 
 var painless = require('..');
-var test = painless.createGroup();
+var test = painless.createGroup('Sync examples');
 var assert = painless.assert;
 
 test('simple sync pass', function sync1() {

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -31,6 +31,10 @@ function handleTest(test) {
   return output.join('');
 }
 
+function handleGroupStart(info) {
+  return info.name ? ('\n' + info.name + '\n') : '\n';
+}
+
 function handleEnd(info) {
   var output = [];
 
@@ -47,6 +51,7 @@ function handleEnd(info) {
 }
 
 module.exports = helper({
+  'group.start': handleGroupStart,
   'test.end': handleTest,
   'end': handleEnd
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -19,7 +19,7 @@ test('command sync -r=tap', function(t) {
 
 test('command sync -r=spec', function(t) {
   exec('node examples/sync -r=spec', function (error, stdout, stderr) {
-    t.match(stdout, /  ✔ simple sync pass [0-9]+ms\n  ✔ simple sync pass 2 [0-9]+ms\n\n\n  [0-9]+ms total\n  2 tests\n  2 passed\n\n  Pass!\n/);
+    t.match(stdout, /Sync examples\n  ✔ simple sync pass [0-9]+ms\n  ✔ simple sync pass 2 [0-9]+ms\n\n\n  [0-9]+ms total\n  2 tests\n  2 passed\n\n  Pass!\n/);
     t.end();
   });
 });


### PR DESCRIPTION
If a group name isn't given, there will be an empty line where the name
would be shown, so it still "chunks" the groups in the reporter's output